### PR TITLE
fix(cfp): sync 2026 PC list in cfp-2026.txt with pages/2026.md

### DIFF
--- a/cfp/2026/cfp-2026.txt
+++ b/cfp/2026/cfp-2026.txt
@@ -25,9 +25,11 @@ Eduardo Fernandes, University of Southern Denmark
 Bjoern Franke, University of Edinburgh
 Rajiv Gupta, University of California, Riverside
 Dongjie He, Chongqing University
+Doug Lea, State Univ. of New York at Oswego
 David H. Lorenz, Open University of Israel
 Hila Peleg, Technion
 Benjamin C. Pierce, University of Pennsylvania
+Taro Sekiyama, National Institute of Informatics
 Abhishek Kr Singh, IIIT Hyderabad
 Yudai Tanabe, Tokyo Institute of Technology
 Didier Verna, EPITA


### PR DESCRIPTION
## Motivation

The Program Committee list in `cfp/2026/cfp-2026.txt` is missing two members
compared with `pages/2026.md`, which is the authoritative baseline:

- **Doug Lea** — State Univ. of New York at Oswego
- **Taro Sekiyama** — National Institute of Informatics

`pages/2026.md` lists 19 PC members; `cfp/2026/cfp-2026.txt` lists only 17.

## Change

Insert the two missing entries into `cfp/2026/cfp-2026.txt` at the positions
that match the alphabetical-by-last-name ordering used in `pages/2026.md`
(Lea after He, Sekiyama after Pierce).

## Visible effect

The plain-text CfP shipped at `cfp/2026/cfp-2026.txt` now lists the same
19 PC members shown on the public 2026 page.

## Test plan

- Diff inspected: only the two missing PC entries are added; no other lines
  changed.
- `bundle exec jekyll build` was **not** runnable in the automation
  environment (rubygems.org and bundler installation are blocked by the
  sandbox proxy). The file lives under `cfp/`, which `_config.yml` lists
  under `exclude:`, so Jekyll does not process it — the site build cannot
  be affected by this change. Keeping the PR in **draft** state until the
  build can be confirmed by CI/a maintainer.
