### PR TITLE
Fix broken Tokyo Tech link on 2026 PC page

### DIFF
--- a/pages/2026.md
+++ b/pages/2026.md
@@ -161,7 +161,7 @@ To be determined...
 ![yudai tanabe](/images/pc/yudai-tanabe.jpg){: width="92" height="92"}
 [Yudai Tanabe](https://scholar.google.co.uk/citations?user=rFnRl1gAAAAJ)
 <br/>
-[Tokyo Institute of Technology](https://yudaitnb.github.io/pages/about)
+[Tokyo Institute of Technology](https://www.titech.ac.jp/english/)
 {: .pc}
 
 ![didier verna](/images/pc/didier-verna.jpg){: width="92" height="92"}


### PR DESCRIPTION
The PC entry for Yudai Tanabe on `pages/2026.md` linked the text "Tokyo Institute of Technology" to `https://yudaitnb.github.io/pages/about`. That URL returns 404 and, more to the point, was pointing at a personal page rather than the institution. Swapped it for `https://www.titech.ac.jp/english/`, which is what the rest of the PC entries do (text matches the institution and points to the institution's site).

Tried to run `bundle exec jekyll build` locally before opening this — the sandbox is missing `ruby-dev` and won't let me install it, so I worked around it (extracted headers and overrode `RbConfig`) and got `json`, `eventmachine`, `http_parser.rb`, and `ffi` to compile, but `sassc` doesn't fit in the available time window and won't resume between runs. Leaving the PR as draft. The change is a single URL string in a markdown file — no frontmatter, layout, or Liquid touched — so GitHub Pages CI is the meaningful build check here.