### PR TITLE
Add missing PC Chair Vladimir Ivanov to cfp-2026.txt

### DIFF
--- a/cfp/2026/cfp-2026.txt
+++ b/cfp/2026/cfp-2026.txt
@@ -17,6 +17,7 @@ Conference: 12 Dec 2026
 
 PROGRAM COMMITTEE
 
+Vladimir Ivanov (Chair), Innopolis University
 Anastasios Antoniadis, University of Athens
 Alexandre Bergel, University of Chile
 Umar Farooq, UCR


### PR DESCRIPTION
## Summary

- `cfp-2026.txt` was missing Vladimir Ivanov (Innopolis University) as PC Chair
- The `2026.md` baseline clearly lists him as PC Chair, but `cfp-2026.txt`'s PROGRAM COMMITTEE section omitted him entirely
- Added `Vladimir Ivanov (Chair), Innopolis University` as the first entry in the PROGRAM COMMITTEE section of `cfp-2026.txt`

## Test plan

- [x] Jekyll build (`bundle exec jekyll build`) passes locally with this change
- [x] Verified `cfp-2026.txt` now matches `2026.md` for the PC Chair entry

https://claude.ai/code/session_01PKKHKr1TrbhkL6WZ7t7cyv