### PR TITLE
Add missing 2025 PC member Rabe Abdalkareem

### DIFF
--- a/pages/2025.md
+++ b/pages/2025.md
@@ -59,6 +59,12 @@ And in alphabetical order:
 [Mälardalen University](https://www.mdu.se/)
 {: .pc}
 
+![rabe abdalkareem](/images/pc/rabe-abdalkareem.jpg){: width="92" height="92"}
+[Rabe Abdalkareem](https://scholar.google.com/citations?user=bCT8sjMAAAAJ)
+<br/>
+[Omar al-Mukhtar University](http://www.omu.edu.ly)
+{: .pc}
+
 ![mohammad alshayeb](/images/pc/mohammad-alshayeb.jpg){: width="92" height="92"}
 [Mohammad Alshayeb](https://scholar.google.com/citations?user=YeZystEAAAAJ)
 <br/>


### PR DESCRIPTION
## Summary

- `Rabe Abdalkareem` (Omar al-Mukhtar University) is listed in `cfp/2025/cfp-2025.txt` as a Program Committee member but was missing from `pages/2025.md`
- Added the entry in alphabetical order between Sara Abbaspour and Mohammad Alshayeb
- Used the existing photo (`/images/pc/rabe-abdalkareem.jpg`) and linked to the correct Google Scholar profile

## Test plan
- [x] Jekyll build passes (`bundle exec jekyll build`)

https://claude.ai/code/session_01PvRfzfiifSztwhKwVa92zm