### PR TITLE
Fix three errors in cfp-2024.tex

### DIFF
--- a/cfp/2024/cfp-2024.tex
+++ b/cfp/2024/cfp-2024.tex
@@ -12,12 +12,12 @@
 
 In cooperation
 with
-\href{https://conferences.ieee.org/conferences_events/conferences/conferencedetails/53703}{IEEE Computer Society}.
+\href{https://conferences.ieee.org/conferences_events/conferences/conferencedetails/60895}{IEEE Computer Society}.
 
 \vspace{6pt}
 
 \PrintAddress
-  {Kazan, Russia}
+  {Innopolis University, Russia}
   {22-Jun-2024 (one day, \textbf{mostly online})}
   {https://easychair.org/cfp/iccq24}
   {EasyChair CFP}
@@ -62,6 +62,6 @@ ICCQ is also sponsored by:
 \href{https://innopolis.university/}{Innopolis University},
 \href{https://www.hse.ru/en/}{HSE University},
 \href{https://english.spbu.ru/}{St. Petersburg University},
-and \href{https://www.iccq.ru/2022.html#partners}{others}.
+and \href{https://www.iccq.ru/2024.html#partners}{others}.
 
 \end{document}


### PR DESCRIPTION
## Summary

Three errors found in `cfp/2024/cfp-2024.tex` by comparing against the authoritative `pages/2024.md` and `cfp/2024/cfp-2024.txt`:

- **Wrong venue address**: `{Kazan, Russia}` → `{Innopolis University, Russia}`. The 2024 conference was held at Innopolis University, not in Kazan — confirmed by `2024.md` (line 26: "Innopolis University, Russia") and `cfp-2024.txt` (line 3: "Venue: Innopolis University, Russia").
- **Wrong IEEE conference ID in link**: `conferencedetails/53703` → `conferencedetails/60895`. The ID `53703` is a stale value carried over from earlier years; `2024.md` uses `60895` for the 2024 ICCQ IEEE cooperation link.
- **Stale partners URL**: `https://www.iccq.ru/2022.html#partners` → `https://www.iccq.ru/2024.html#partners`. The link incorrectly pointed to the 2022 edition's partners page.

## Test plan

- [x] `bundle exec jekyll build` passes with no errors

https://claude.ai/code/session_017B4VWUYU2NWtoBC7WQh89j