### PR TITLE
Fix typo in cfp-2023.txt: '3nd' -> '3rd'

### DIFF
--- a/cfp/2023/cfp-2023.txt
+++ b/cfp/2023/cfp-2023.txt
@@ -1,4 +1,4 @@
-Name: 3nd International Conference on Code Quality (ICCQ)
+Name: 3rd International Conference on Code Quality (ICCQ)
 Date: April 22, 2023
 Venue: St. Petersburg State University, Russia
 Website: https://www.iccq.ru/2023.html


### PR DESCRIPTION
## Summary

- Fixed a typo in `cfp/2023/cfp-2023.txt`: the conference name was incorrectly written as "3nd International Conference on Code Quality" — it should be "3rd".

## Test plan

- [x] `bundle exec jekyll build` passes successfully

https://claude.ai/code/session_01Y9SrCS1axfCVm1hwmUa6V8