### PR TITLE
Fix CFP text file inconsistencies: wrong conference date and ordinal typo

### DIFF
--- a/cfp/2022/cfp-2022.txt
+++ b/cfp/2022/cfp-2022.txt
@@ -17,7 +17,7 @@ IMPORTANT DATES
 Paper/abstract submission: 31 Dec 2021 (anywhere on Earth)
 Author notification: 1 Mar 2022
 Camera-ready submissions: 25 Mar 2022
-Conference: 23 Mar 2022
+Conference: 23 Apr 2022
 
 KEYNOTE SPEECH
 

--- a/cfp/2023/cfp-2023.txt
+++ b/cfp/2023/cfp-2023.txt
@@ -1,4 +1,4 @@
-Name: 3nd International Conference on Code Quality (ICCQ)
+Name: 3rd International Conference on Code Quality (ICCQ)
 Date: April 22, 2023
 Venue: St. Petersburg State University, Russia
 Website: https://www.iccq.ru/2023.html


### PR DESCRIPTION
## Summary

- `cfp/2022/cfp-2022.txt`: The **Important Dates** section listed `Conference: 23 Mar 2022`, but the actual conference date was **April 23, 2022** (as shown in `pages/2022.md` and even the header of the same .txt file). The camera-ready deadline of March 25 also makes it obvious that March 23 as the conference date is impossible.
- `cfp/2023/cfp-2023.txt`: First line read `3nd International Conference` — ordinal typo, should be `3rd`.

Both files are inconsistent with `pages/2022.md` and `pages/2023.md` which serve as the canonical source of truth.

## Test plan

- [x] `bundle exec jekyll build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E65iDMPyAkUQfjX8MfAdNK