### PR TITLE
Fix wrong alt text for Giancarlo Succi photo in 2021 page

### DIFF
--- a/pages/2021.md
+++ b/pages/2021.md
@@ -223,7 +223,7 @@ Alexander Gerasimov
 [University of Paderborn](https://www.uni-paderborn.de/en/university/)<!--, Germany-->
 {: .pc}
 
-![yulei sui](/images/pc/giancarlo-succi.jpg){: width="92" height="92"}
+![giancarlo succi](/images/pc/giancarlo-succi.jpg){: width="92" height="92"}
 [Giancarlo Succi](https://scholar.google.com/citations?user=PdMO57sAAAAJ)
 <br/>
 [Innopolis University](https://innopolis.university/en/)<!--, Russia-->


### PR DESCRIPTION
## Summary

In \`pages/2021.md\`, the image alt attribute for Giancarlo Succi's photo incorrectly said \`"yulei sui"\` instead of \`"giancarlo succi"\`. This is a copy-paste error — the Yulei Sui entry appears immediately after, so the alt text was accidentally duplicated.

**Before:**
\`\`\`markdown
[yulei sui](/images/pc/giancarlo-succi.jpg){: width="92" height="92"}
[Giancarlo Succi](https://scholar.google.com/citations?user=PdMO57sAAAAJ)
\`\`\`

**After:**
\`\`\`markdown
[giancarlo succi](/images/pc/giancarlo-succi.jpg){: width="92" height="92"}
[Giancarlo Succi](https://scholar.google.com/citations?user=PdMO57sAAAAJ)
\`\`\`

## Test plan

- [x] \`bundle exec jekyll build\` passes with no errors

---
_Generated by [Claude Code](https://claude.ai/code)_