### PR TITLE
Fix two errors in cfp/2022/cfp-2022.txt

### DIFF
--- a/cfp/2022/cfp-2022.txt
+++ b/cfp/2022/cfp-2022.txt
@@ -17,11 +17,11 @@ IMPORTANT DATES
 Paper/abstract submission: 31 Dec 2021 (anywhere on Earth)
 Author notification: 1 Mar 2022
 Camera-ready submissions: 25 Mar 2022
-Conference: 23 Mar 2022
+Conference: 23 Apr 2022
 
 KEYNOTE SPEECH
 
-Charles Zhang, HKSUT
+Charles Zhang, HKUST
 
 STEERING COMMITTEE
 


### PR DESCRIPTION
## Summary

- Fixed wrong conference month: `Conference: 23 Mar 2022` → `Conference: 23 Apr 2022` (the .md baseline and the file's own header both say April)
- Fixed typo in keynote speaker's university: `HKSUT` → `HKUST` (confirmed by `pages/2022.md` and `cfp/2022/cfp-2022.tex`)

Both errors are in `cfp/2022/cfp-2022.txt` and contradict the `.md` baseline file (`pages/2022.md`).

## Test plan

- [x] `bundle exec jekyll build` passes locally