### PR TITLE
Fix ordinal typo in cfp-2023.txt

### DIFF
--- a/cfp/2023/cfp-2023.txt
+++ b/cfp/2023/cfp-2023.txt
@@ -1,4 +1,4 @@
-Name: 3nd International Conference on Code Quality (ICCQ)
+Name: 3rd International Conference on Code Quality (ICCQ)
 Date: April 22, 2023
 Venue: St. Petersburg State University, Russia
 Website: https://www.iccq.ru/2023.html


### PR DESCRIPTION
Fixed typo: "3nd" -> "3rd" in cfp-2023.txt. The pages/2023.md (baseline) correctly uses "3rd".