### PR TITLE
Fix Alexandra Jimborean's affiliation in cfp-2022.txt

### DIFF
--- a/cfp/2022/cfp-2022.txt
+++ b/cfp/2022/cfp-2022.txt
@@ -40,7 +40,7 @@ Shigeru Chiba, University of Tokyo
 Christian Hammer, University of Passau
 Mats Heimdahl, University of Minnesota
 Robert Hirschfeld, University of Potsdam
-Alexandra Jimborean, Uppsala University
+Alexandra Jimborean, University of Murcia
 David H. Lorenz, Open University of Israel
 Hidehiko Masuhara, Tokyo Institute of Technology
 Hausi A. Müller, University of Victoria


### PR DESCRIPTION
## Summary

The `pages/2022.md` file (the baseline) lists Alexandra Jimborean as being affiliated with **University of Murcia**, but `cfp/2022/cfp-2022.txt` incorrectly listed her as **Uppsala University**.

- Fixed: `cfp/2022/cfp-2022.txt` — changed "Uppsala University" → "University of Murcia" for Alexandra Jimborean
- Build verified: `bundle exec jekyll build` passes without errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTHUaEYxcNG5GudXSYsN9r)_