### PR TITLE
Fix 2026 proceedings: correct PC Chair, members, and conference number

### DIFF
--- a/proceedings/2026/parts/orgs.tex
+++ b/proceedings/2026/parts/orgs.tex
@@ -12,26 +12,26 @@
 Program Committee:
 
 \begin{itemize}
-\pc{\nospell{Alexander Legalov (Chair)}}{\nospell{HSE University}}
-\pc{\nospell{Sara Abbaspour}}{\nospell{Mälardalen University}}
-\pc{\nospell{Rabe Abdalkareem}}{\nospell{Omar al-Mukhtar University}}
-\pc{\nospell{Mohammad Alshayeb}}{\nospell{King Fahd University of Petroleum and Minerals}}
-\pc{\nospell{Thomas Ball}}{\nospell{Microsoft Research}}
-\pc{\nospell{Pietro Braione}}{\nospell{University of Milano-Bicocca}}
-\pc{\nospell{Jacques Carette}}{\nospell{McMaster University}}
-\pc{\nospell{Bernhard Egger}}{\nospell{Seoul National University}}
-\pc{\nospell{Umar Farooq}}{\nospell{Louisiana State University}}
+\pc{\nospell{Vladimir Ivanov (Chair)}}{\nospell{Innopolis University}}
+\pc{\nospell{Anastasios Antoniadis}}{\nospell{University of Athens}}
+\pc{\nospell{Alexandre Bergel}}{\nospell{University of Chile}}
+\pc{\nospell{Umar Farooq}}{\nospell{UCR}}
+\pc{\nospell{Jérôme Feret}}{\nospell{Inria}}
 \pc{\nospell{Eduardo Fernandes}}{\nospell{University of Southern Denmark}}
-\pc{\nospell{Javier Luis Cánovas Izquierdo}}{\nospell{Universitat Oberta de Catalunya}}
-\pc{\nospell{Ranjit Jhala}}{\nospell{University of California, San Diego}}
-\pc{\nospell{Antoine Miné}}{\nospell{Sorbonne Université}}
-\pc{\nospell{Murali Krishna Ramanathan}}{\nospell{Amazon Web Services}}
-\pc{\nospell{Francis Palma}}{\nospell{University of New Brunswick}}
-\pc{\nospell{Amr Sabry}}{\nospell{Indiana University}}
-\pc{\nospell{Bjorn De Sutter}}{\nospell{Ghent University}}
-\pc{\nospell{G. Gary Tan}}{\nospell{Pennsylvania State University}}
+\pc{\nospell{Bjoern Franke}}{\nospell{University of Edinburgh}}
+\pc{\nospell{Rajiv Gupta}}{\nospell{University of California, Riverside}}
+\pc{\nospell{Dongjie He}}{\nospell{Chongqing University}}
+\pc{\nospell{Doug Lea}}{\nospell{State Univ. of New York at Oswego}}
+\pc{\nospell{David H. Lorenz}}{\nospell{Open University of Israel}}
+\pc{\nospell{Umang Mathur}}{\nospell{National University of Singapore}}
+\pc{\nospell{Hila Peleg}}{\nospell{Technion}}
+\pc{\nospell{Benjamin C. Pierce}}{\nospell{University of Pennsylvania}}
+\pc{\nospell{Taro Sekiyama}}{\nospell{National Institute of Informatics}}
+\pc{\nospell{Abhishek Kr Singh}}{\nospell{IIIT Hyderabad}}
+\pc{\nospell{Yudai Tanabe}}{\nospell{Tokyo Institute of Technology}}
 \pc{\nospell{Didier Verna}}{\nospell{EPITA}}
-\pc{\nospell{Guowei Yang}}{\nospell{University of Queensland}}
+\pc{\nospell{Philip Wadler}}{\nospell{University of Edinburgh}}
+\pc{\nospell{Enea Zaffanella}}{\nospell{University of Parma}}
 \pc{\nospell{Vadim Zaytsev}}{\nospell{University of Twente}}
 \end{itemize}
 
@@ -40,9 +40,7 @@ Organizers:
 \begin{itemize}
 \item \nospell{Yegor Bugayenko} (Chair)
 \item \nospell{Sergey Belov}
-\item \nospell{Vasilii Borisov}
-\item \nospell{Ksenia Gyrdimova}
-\item \nospell{Anna Kazmina}
-\item \nospell{Ilya Obabkov}
+\item \nospell{Maria Eliseeva}
+\item \nospell{Andrey Palyanov}
 \end{itemize}
 \end{multicols}

--- a/proceedings/2026/parts/preface-org.tex
+++ b/proceedings/2026/parts/preface-org.tex
@@ -4,7 +4,7 @@
 \cleardoublepage
 \sect{Message from Organizers}
 
-We welcome you to the fifth ICCQ conference, organized in partnership with IEEE Computer Society.
+We welcome you to the sixth ICCQ conference, organized in partnership with IEEE Computer Society.
 
 The purpose of our conference, which we intend to continue for years to come, is to connect computer scientists from the West with universities and researchers in Russia.
 We aspire to position ICCQ alongside the conferences we hold in high regard, including OOPSLA, PLDI, and POPL.
@@ -13,13 +13,14 @@ We recognize that a long journey lies ahead, and we remain committed to realizin
 The quality of ICCQ is our foremost priority.
 For us, quality means rigorous and impartial peer review.
 To evaluate submissions thoroughly and select the best for publication, we rely on a professional and dedicated Program Committee.
-This year, we are proud to have two ACM Fellows on our Program Committee:
-  Thomas Ball from Microsoft Research
+This year, we are proud to have three ACM Fellows on our Program Committee:
+  Doug Lea from the State University of New York at Oswego,
+  Benjamin C. Pierce from the University of Pennsylvania,
   and
-  Ranjit Jhala from the University of California, San Diego.
+  Philip Wadler from the University of Edinburgh.
 We are grateful to all PC members for their dedicated efforts in providing thorough reviews.
 
-We could not have organized this conference without Ural Federal University and IEEE Russia~(Siberia) Section, our valued and supportive partners.
+We could not have organized this conference without A.P.~Ershov Institute of Informatics Systems, our valued and supportive partner.
 
 Above all, the most valuable contribution came from the authors who chose ICCQ as the publication venue for their work.
 We look forward to receiving their submissions at future ICCQ conferences.

--- a/proceedings/2026/parts/preface-program.tex
+++ b/proceedings/2026/parts/preface-program.tex
@@ -19,9 +19,9 @@ I accepted with gratitude the organizers’ invitation to ICCQ and tried to offe
 I would also like to note the considerable work carried out by the organizing committee, which made it possible to host the conference at a high level.
 I wish the participants and organizers continued creative success and the achievement of new scientific results that contribute to improving software quality.
 
-\index{Legalov, Alexander}
+\index{Ivanov, Vladimir}
 \vspace{18pt}
 Sincerely,\\
-Prof. \nospell{Alexander Legalov}\\
-HSE University \\
+Prof. \nospell{Vladimir Ivanov}\\
+Innopolis University \\
 Chairman of the Program Committee \\


### PR DESCRIPTION
## Summary

The `proceedings/2026/parts/` directory contained content copied verbatim from 2025 that was never updated for 2026. Three files had incorrect information that directly contradicts the authoritative `pages/2026.md`:

- **`preface-program.tex`**: Listed Alexander Legalov (HSE University) as the PC Chair, but the 2026 PC Chair is Vladimir Ivanov (Innopolis University). Legalov was the 2025 PC Chair.
- **`preface-org.tex`**: Said "fifth ICCQ conference" (should be sixth); named Thomas Ball and Ranjit Jhala as the ACM Fellows on the PC (they were 2025 PC members, not 2026); referenced Ural Federal University as the host partner (was the 2025 partner — 2026 is hosted by A.P. Ershov Institute of Informatics Systems).
- **`orgs.tex`**: Listed the entire 2025 PC roster (Legalov as Chair plus 20 2025 members) and 2025 organizers, instead of the 2026 PC (Ivanov as Chair plus 20 2026 members) and 2026 organizers.

All changes were derived from `pages/2026.md`, which is the baseline source of truth.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWtb69z4gN9aNPQVeC72Pv)_