### PR TITLE
Fix 2022 CFP txt: add missing PC members and fix affiliation

### DIFF
--- a/cfp/2022/cfp-2022.txt
+++ b/cfp/2022/cfp-2022.txt
@@ -37,10 +37,11 @@ Carl Friedrich Bolz-Tereick, Heinrich-Heine-Universität Düsseldorf
 William J. Bowman, University of British Columbia
 Laura M. Castro, Universidade da Coruña
 Shigeru Chiba, University of Tokyo
+Daniele Cono D'Elia, Sapienza University of Rome
 Christian Hammer, University of Passau
 Mats Heimdahl, University of Minnesota
 Robert Hirschfeld, University of Potsdam
-Alexandra Jimborean, Uppsala University
+Alexandra Jimborean, University of Murcia
 David H. Lorenz, Open University of Israel
 Hidehiko Masuhara, Tokyo Institute of Technology
 Hausi A. Müller, University of Victoria
@@ -50,6 +51,7 @@ Veselin Raychev, ETH
 Tiark  Rompf, Purdue University
 Yulei Sui, University of Technology Sydney
 Will Tracz, IFIP
+Qianxiang Wang, Huawei
 Laurie Williams, North Carolina State University
 Tuba Yavuz, University of Florida
 


### PR DESCRIPTION
## Summary

The `cfp/2022/cfp-2022.txt` was inconsistent with `pages/2022.md` (the baseline) in three ways:

- **Missing PC member**: Daniele Cono D'Elia (Sapienza University of Rome) is listed in `2022.md` but was absent from `cfp-2022.txt`
- **Missing PC member**: Qianxiang Wang (Huawei) is listed in `2022.md` but was absent from `cfp-2022.txt`
- **Wrong affiliation**: Alexandra Jimborean is listed as "Uppsala University" in `cfp-2022.txt` but as "University of Murcia" in `2022.md`

The `.md` file is the authoritative baseline; the `.txt` file has been updated to match it. The Jekyll build passes after the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_016rRm25C8vtx3kV1iV3n9Jf)_