### PR TITLE
Fix duplicate "in cooperation" phrase in 2026.md

### DIFF
--- a/pages/2026.md
+++ b/pages/2026.md
@@ -44,7 +44,7 @@ programming languages design,
 software bug detection,
 and software maintenance.
 
-ICCQ is organized in cooperation
+ICCQ is organized
 [in cooperation](https://conferences.ieee.org/conferences_events/conferences/conferencedetails/72368)
 with
 [A.P. Ershov Institute of Informatics Systems](https://www.iis.nsk.su/en)


### PR DESCRIPTION
## Summary

- In `pages/2026.md`, the phrase "in cooperation" appeared twice on consecutive lines: once as plain text ("ICCQ is organized in cooperation") and again as the link label ("[in cooperation](url)"). This caused the rendered page to read "ICCQ is organized in cooperation in cooperation with…" — a clear duplication.
- Removed the redundant plain-text "in cooperation" so the sentence now reads correctly: "ICCQ is organized [in cooperation](url) with…", consistent with the pattern used in `pages/2025.md`.
- Jekyll build (`bundle exec jekyll build`) passes after the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4M7zBSNn3zVnybHXrbLYP)_