### PR TITLE
Fix Alexandra Jimborean's affiliation in cfp-2022.txt

### DIFF
--- a/cfp/2022/cfp-2022.txt
+++ b/cfp/2022/cfp-2022.txt
@@ -40,7 +40,7 @@ Shigeru Chiba, University of Tokyo
 Christian Hammer, University of Passau
 Mats Heimdahl, University of Minnesota
 Robert Hirschfeld, University of Potsdam
-Alexandra Jimborean, Uppsala University
+Alexandra Jimborean, University of Murcia
 David H. Lorenz, Open University of Israel
 Hidehiko Masuhara, Tokyo Institute of Technology
 Hausi A. Müller, University of Victoria


### PR DESCRIPTION
## Summary

The `cfp/2022/cfp-2022.txt` file listed Alexandra Jimborean's affiliation as **Uppsala University**, which does not match the `.md` baseline (`pages/2022.md`) where she is listed at **University of Murcia**.

This fix corrects the `.txt` file to match the `.md` baseline.

## Change

- `cfp/2022/cfp-2022.txt`: `Alexandra Jimborean, Uppsala University` → `Alexandra Jimborean, University of Murcia`

The Jekyll build (`bundle exec jekyll build`) passes with no errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdnMoEsCNWHR2GWG8VWDRq)_