### PR TITLE
Fix paper submission date in cfp-2026.tex

### DIFF
--- a/cfp/2026/cfp-2026.tex
+++ b/cfp/2026/cfp-2026.tex
@@ -48,7 +48,7 @@ will appear in \href{https://ieeexplore.ieee.org/Xplore/home.jsp}{IEEE Xplore\te
 and will be indexed by Scopus.
 
 \begin{tabular}{@{}ll}
-Paper/abstract submission date: & 17 Aug 2026 \\
+Paper/abstract submission date: & 27 Aug 2026 \\
 Author notification: & 1 Nov 2026 \\
 Camera-ready submissions: & 25 Nov 2026
 \end{tabular}


### PR DESCRIPTION
## Summary

- `cfp/2026/cfp-2026.tex` listed the paper/abstract submission deadline as **17 Aug 2026**
- Both `pages/2026.md` (the authoritative source) and `cfp/2026/cfp-2026.txt` list it as **27 Aug 2026**
- This PR fixes the `.tex` file to match the correct date of 27 Aug 2026

The Jekyll build passes locally after this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JgBNWSrWxMzUW8MqZnTs5)_