### PR TITLE
Fix wrong year and city in 2027.md

### DIFF
--- a/pages/2027.md
+++ b/pages/2027.md
@@ -5,7 +5,7 @@ layout: default
 year: 2027
 date: 2026-08-28
 title: "ICCQ-2027: 7th International Conference on Code Quality"
-description: "The 7th International Conference on Code Quality (ICCQ), a hybrid event on 11 December 2026 in Novosibirsk, Russia, covers static and dynamic analysis, program verification, programming languages design, bug detection, and software maintenance."
+description: "The 7th International Conference on Code Quality (ICCQ), a hybrid event on 11 December 2027 in Moscow, Russia, covers static and dynamic analysis, program verification, programming languages design, bug detection, and software maintenance."
 start_date: 2027-12-11
 location_name: Moscow
 location_country: RU
@@ -78,7 +78,7 @@ Camera-ready submissions:<br>
 25 Nov 2027
 
 Conference:<br>
-11 Dec 2026
+11 Dec 2027
 
 ## Call for Papers # {#cfp}
 
@@ -192,5 +192,5 @@ Registration is free of charge.
 [youtube]: https://www.youtube.com/channel/UC_W-pjp6HWJGjK2sayFrnag
 [double-blind]: https://www.journals.elsevier.com/social-science-and-medicine/policies/double-blind-peer-review-guidelines
 [WoS]: https://clarivate.com/webofsciencegroup/solutions/web-of-science/
-[PDF version]: https://github.com/yegor256/iccq.github.io/blob/pdf/iccq-cfp-2026.pdf
+[PDF version]: https://github.com/yegor256/iccq.github.io/blob/pdf/iccq-cfp-2027.pdf
 [cfp@iccq.ru]: mailto:cfp@iccq.ru


### PR DESCRIPTION
## Summary

The `pages/2027.md` file had three copy-paste errors from the 2026 page:

- **Description field** (line 8): said "11 December 2026 in Novosibirsk" — should be "11 December 2027 in Moscow". The front matter already has `start_date: 2027-12-11` and `location_name: Moscow`, and the body text says "Sat 11 December 2027 / Moscow, Russia".
- **Important Dates section** (line 81): "Conference: 11 Dec 2026" — should be "11 Dec 2027".
- **PDF version link** (line 195): pointed to `iccq-cfp-2026.pdf` — should be `iccq-cfp-2027.pdf`.

The build (`bundle exec jekyll build`) passes with no errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPSRTW7FvdmXCRRQ9ggBuS)_